### PR TITLE
KONDO ICSのサポート

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 pyserial = "*"
+packaging = "*"
 
 [requires]
 python_version = "3.8.1"

--- a/gs2d/Kondo.py
+++ b/gs2d/Kondo.py
@@ -1,0 +1,1423 @@
+import time
+import logging
+
+from .ICommandHandler import ICommandHandler
+from .ISerialInterface import ISerialInterface
+from .Driver import Driver
+from .Util import ReceiveDataTimeoutException, NotSupportException, BadInputParametersException, WrongCheckSumException
+from .Util import InvalidResponseDataException
+from .Util import get_printable_hex
+
+# ロガー
+logger = logging.getLogger(__name__)
+
+
+class Futaba(Driver):
+    """Futabaのシリアルサーボクラス
+
+    """
+
+    # アドレス空間
+    ADDR_MODEL_NUMBER_L = 0  # 0x00
+    ADDR_FIRMWARE_VERSION = 2  # 0x02
+    ADDR_SERVO_ID = 4  # 0x04
+    ADDR_REVERSE = 5  # 0x05
+    ADDR_BAUD_RATE = 6  # 0x06
+    ADDR_RETURN_DELAY = 7  # 0x07
+    ADDR_CW_ANGLE_LIMIT_L = 8  # 0x08
+    ADDR_CCW_ANGLE_LIMIT_L = 10  # 0x0A
+    ADDR_TEMPERATURE_LIMIT_L = 14  # 0x0E
+    ADDR_TORQUE_IN_SILENCE = 22  # 0x16
+    ADDR_WARM_UP_TIME = 23  # 0x17
+    ADDR_CW_COMPLIANCE_MARGIN = 24  # 0x18
+    ADDR_CCW_COMPLIANCE_MARGIN = 25  # 0x19
+    ADDR_CW_COMPLIANCE_SLOPE = 26  # 0x1A
+    ADDR_CCW_COMPLIANCE_SLOPE = 27  # 0x1B
+    ADDR_PUNCH_L = 28  # 0x1C
+
+    ADDR_GOAL_POSITION_L = 30  # 0x1E
+    ADDR_GOAL_TIME_L = 32  # 0x20
+    ADDR_MAX_TORQUE = 35  # 0x23
+    ADDR_TORQUE_ENABLE = 36  # 0x24
+    ADDR_PID_COEFFICIENT = 38  # 0x26
+    ADDR_PRESENT_POSITION_L = 42  # 0x2A
+    ADDR_PRESENT_TIME_L = 44  # 0x2C
+    ADDR_PRESENT_SPEED_L = 46  # 0x2E
+    ADDR_PRESENT_CURRENT_L = 48  # 0x30
+    ADDR_TEMPERATURE_L = 50  # 0x32
+    ADDR_VOLTAGE_L = 52  # 0x34
+
+    ADDR_WRITE_FLASH_ROM = 255  # 0xFF
+    ADDR_RESET_MEMORY = 255  # 0xFF
+
+    # フラグ
+    FLAG4_RESET_MEMORY_MAP = 16  # 0x10
+    FLAG30_NO_RETURN_PACKET = 0
+    FLAG30_MEM_MAP_ACK = 1
+    FLAG30_MEM_MAP_00_29 = 3
+    FLAG30_MEM_MAP_30_59 = 5
+    FLAG30_MEM_MAP_20_29 = 7
+    FLAG30_MEM_MAP_42_59 = 9
+    FLAG30_MEM_MAP_30_41 = 11
+    FLAG30_MEM_MAP_60_127 = 13
+    FLAG30_MEM_MAP_SELECT = 15
+
+    PACKET_DATA_INDEX = 7
+
+    # 通信速度のIDと実際の設定値
+    BAUD_RATE_INDEX_9600 = 0x00
+    BAUD_RATE_INDEX_14400 = 0x01
+    BAUD_RATE_INDEX_19200 = 0x02
+    BAUD_RATE_INDEX_28800 = 0x03
+    BAUD_RATE_INDEX_38400 = 0x04
+    BAUD_RATE_INDEX_57600 = 0x05
+    BAUD_RATE_INDEX_76800 = 0x06
+    BAUD_RATE_INDEX_115200 = 0x07
+    BAUD_RATE_INDEX_153600 = 0x08
+    BAUD_RATE_INDEX_230400 = 0x09
+
+    def __init__(self, serial_interface: ISerialInterface, command_handler_class: ICommandHandler = None):
+        """初期化
+        """
+
+        super(Futaba, self).__init__(serial_interface, command_handler_class)
+
+    def is_complete_response(self, response_data):
+        """レスポンスデータをすべて受信できたかチェック"""
+        # print('#########', response_data)
+
+        # Header, ID, Flags, Address, Length, Count, Data, Sum で7バイトは最低限ある
+        if len(response_data) < 6:
+            return False
+        else:
+            # カウント取得
+            count = response_data[5]
+            # print('####', count, len(response_data))
+            return len(response_data) == (8 + count)
+
+    @staticmethod
+    def __get_checksum(data):
+        """チェックサムを生成
+
+        :param data:
+        :return:
+        """
+
+        checksum = 0
+        for i in range(2, len(data)):
+            checksum ^= data[i]
+        return checksum
+
+    @staticmethod
+    def __check_sid(sid):
+        """Servo IDのレンジをチェック
+
+        :param sid:
+        :return:
+        """
+
+        if sid < 1 or sid > 127:
+            raise BadInputParametersException('sid: %d がレンジ外です。1から127のIDを設定してください。' % sid)
+
+    def __generate_command(self, sid, addr, data=None, flag=0, count=1, length=None):
+        """コマンド生成
+
+        :param sid:  Servo ID
+        :param addr:
+        :param data:
+        :param flag:
+        :param count:
+        :param length:
+        :return:
+        """
+
+        # Header:   パケットの先頭を表します。ショートパケットではFAAFに設定します。
+        # ID:       サーボのIDです。1~127(01H~7FH)までの値が使用できます。
+        #           ID:255を指定すると、全IDのサーボへの共通指令になります(リターンデータは取れません)。
+        # Flag:     サーボからのリターンデータ取得やデータ書き込み時の設定をします
+        # Address:  メモリーマップ上のアドレスを指定します。
+        #           このアドレスから「Length」に指定した長さ分のデータをメモリーマップに書き込みます。
+        # Length:   データ1ブロックの長さを指定します。ショートパケットでは Dataのバイト数になります。
+        # Count:    サーボの数を表します。ショートパケットでメモリーマップに書き込む時は 1 に設定します。
+        # Data:     メモリーマップに書き込むデータです
+        # Checksum: 送信データの確認用のチェックサムで、パケットのIDからDataの末尾までを1バイトずつ
+        #           XORした値を指定します。
+
+        command = []
+
+        # Header
+        command.extend([0xFA, 0xAF])
+
+        # ID
+        command.append(sid)
+
+        # Flag
+        command.append(flag)
+
+        # Address
+        command.append(addr)
+
+        # Length
+        if length is not None:
+            command.append(length)
+        elif data is not None:
+            command.append(len(data))
+        else:
+            command.append(0)
+
+        # Count
+        command.append(count)
+
+        # Data
+        if data is not None and len(data) > 0:
+            command.extend(data)
+
+        # Checksum
+        command.append(self.__get_checksum(command))
+
+        return command
+
+    def __generate_burst_command(self, addr, length, vid_data_dict):
+        """バーストコマンド生成
+
+        :param addr:
+        :param length:
+        :param vid_data_dict:
+        :return:
+        """
+
+        # Header:  パケットの先頭を表します。ショートパケットではFAAFに設定します。
+        # ID:      常に00
+        # Flag:    常に00
+        # Address: メモリーマップ上のアドレスを指定します。
+        #          このアドレスから「Length」に指定した長さ分のデータを指定した複数サーボのメモリーマップに書き込みます。
+        # Length:  サーボ1つ分のデータ (VIDData) のバイト数を指定します。
+        # Count:   データを送信する対象となるサーボの数を表します。この数分 VID と Data を送信します。
+        # VID:     データを送信する個々のサーボの ID を表します。VID と Data が一組でサーボの数分のデータを送信します。
+        # Data:    メモリーマップに書き込むサーボ一つ分のデータです。VID と Data が一組でサーボの数分のデータを送信します。
+        # Sum:     送信データの確認用のチェックサムで、パケットのIDからDataの末尾までを1バイトずつ
+        #          XORした値を指定します。
+
+        command = []
+
+        # Header
+        command.extend([0xFA, 0xAF])
+
+        # ID
+        command.append(0)
+
+        # Flag
+        command.append(0)
+
+        # Address
+        command.append(addr)
+
+        # Length
+        command.append(length)
+
+        # Count
+        command.append(len(vid_data_dict))
+
+        # Data
+        for sid, data in vid_data_dict.items():
+            command.append(sid)
+
+            if data is not None and len(data) > 0:
+                command.extend(data)
+
+        # Checksum
+        command.append(self.__get_checksum(command))
+
+        return command
+
+    def __get_function(self, address, flag, length, response_process, sid=1, callback=None):
+        """Get系の処理をまとめた関数
+
+        :param address:
+        :param flag:
+        :param length:
+        :param response_process:
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # データ
+        data = None
+
+        # 受信済みフラグ
+        is_received = False
+
+        # チェックサム不正エラー
+        is_checksum_error = False
+
+        def temp_recv_callback(response):
+            nonlocal data
+            nonlocal is_received
+            nonlocal is_checksum_error
+
+            recv_data = None
+
+            # レスポンスデータのチェックサムが正しいかチェック
+            if self.__get_checksum(response[:-1]) != response[-1]:
+                logger.debug('Check sum error: ' + get_printable_hex(response))
+                is_checksum_error = True
+                return
+
+            # 受信済み
+            is_received = True
+
+            if len(response) > self.PACKET_DATA_INDEX + length:
+                response_data = response[self.PACKET_DATA_INDEX:self.PACKET_DATA_INDEX + length]
+                recv_data = response_process(response_data)
+
+            if callback is not None:
+                callback(recv_data)
+            else:
+                data = recv_data
+
+        command = self.__generate_command(sid, address, flag=flag, count=0, length=length)
+        self.command_handler.add_command(command, recv_callback=temp_recv_callback)
+
+        # コールバックが設定できていたら、コールバックに受信データを渡す
+        if callback is None:
+            # 指定以内にサーボからデータを受信できたかをチェック
+            start = time.time()
+            while not is_received:
+                elapsed_time = time.time() - start
+                if elapsed_time > self.command_handler.RECEIVE_DATA_TIMEOUT_SEC:
+                    raise ReceiveDataTimeoutException(str(self.command_handler.RECEIVE_DATA_TIMEOUT_SEC) + '秒以内にデータ受信できませんでした')
+                elif is_checksum_error:
+                    raise WrongCheckSumException('受信したデータのチェックサムが不正です')
+
+            return data
+        else:
+            return True
+
+    def get_torque_enable(self, sid, callback=None):
+        """トルクON取得
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 1:
+                return response_data[0] == 0x01
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_TORQUE_ENABLE, self.FLAG30_MEM_MAP_SELECT, 1, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_torque_enable_async(self, sid, loop=None):
+        """トルクON取得async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_torque_enable(sid, callback=callback)
+        return f
+
+    def close(self, force=False):
+        """閉じる
+
+        :param force:
+        :return:
+        """
+
+        if self.command_handler:
+            self.command_handler.close()
+
+    def ping(self, sid, callback=None):
+        """サーボにPINGを送る
+        FutabaにはPINGコマンドはないので、get_servo_idで代用。
+
+        :param sid:
+        :param callback:
+        :return: {
+            'model_no': bytearray (2bytes),
+            'version_firmware': int (1byte)
+        }
+        """
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 3:
+                model_no = int.from_bytes(response_data[0:2], 'little', signed=True)
+                version_firmware = response_data[2]
+                return {
+                    'model_no': model_no,
+                    'version_firmware': version_firmware
+                }
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_MODEL_NUMBER_L, self.FLAG30_MEM_MAP_SELECT, 3, response_process,
+                                   sid=sid, callback=callback)
+
+    def ping_async(self, sid, loop=None):
+        """サーボにPINGを送る async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.ping(sid, callback=callback)
+        return f
+
+    def set_torque_enable(self, on_off, sid):
+        """トルクON/OFF設定
+
+        :param on_off:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # トルクデータ
+        torque_data = 0x01 if on_off else 0x00
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_TORQUE_ENABLE, [torque_data])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_temperature(self, sid, callback=None):
+        """温度取得（単位: ℃。おおよそ±3℃程度の誤差あり）
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                temperature = int.from_bytes(response_data, 'little', signed=True)
+                return temperature
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_TEMPERATURE_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_temperature_async(self, sid, loop=None):
+        """温度取得 async版（単位: ℃。おおよそ±3℃程度の誤差あり）
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_temperature(sid, callback=callback)
+        return f
+
+    def get_current(self, sid, callback=None):
+        """電流(現在の負荷)取得 (単位: mA)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                current = int.from_bytes(response_data, 'little', signed=False)
+                return current
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_PRESENT_CURRENT_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_current_async(self, sid, loop=None):
+        """電流(現在の負荷)取得 async版 (単位: mA)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_current(sid, callback=callback)
+        return f
+
+    def get_target_position(self, sid, callback=None):
+        """指示位置取得 (単位: 度)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                # 単位は 0.1 度になっているので、度に変換
+                position = int.from_bytes(response_data, 'little', signed=True)
+                position /= 10
+                return -position
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_GOAL_POSITION_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_target_position_async(self, sid, loop=None):
+        """指示位置取得 async版 (単位: 度)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_target_position(sid, callback=callback)
+        return f
+
+    def set_target_position(self, position_degree, sid=1):
+        """指示位置設定 (単位: 度。設定可能な範囲は-150.0 度~150.0 度)
+
+        :param position_degree:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # 設定可能な範囲は-150.0 度~150.0 度
+        if position_degree < -150:
+            position_degree = -150
+        elif position_degree > 150:
+            position_degree = 150
+
+        position_hex = format(int(position_degree * -10) & 0xffff, '04x')
+        position_hex_h = int(position_hex[0:2], 16)
+        position_hex_l = int(position_hex[2:4], 16)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_GOAL_POSITION_L, [position_hex_l, position_hex_h])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_current_position(self, sid, callback=None):
+        """現在位置取得 (単位: 度)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                # 単位は 0.1 度になっているので、度に変換
+                position = int.from_bytes(response_data, 'little', signed=True)
+                position /= 10
+                return -position
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_PRESENT_POSITION_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_current_position_async(self, sid, loop=None):
+        """現在位置取得 async版 (単位: 度)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_current_position(sid, callback=callback)
+        return f
+
+    def get_offset(self, sid, callback=None):
+        raise NotSupportException('Futabaではget_offsetに対応していません。')
+
+    def get_offset_async(self, sid, loop=None):
+        raise NotSupportException('Futabaではget_offset_asyncに対応していません。')
+
+    def set_offset(self, offset, sid):
+        raise NotSupportException('Futabaではset_offsetに対応していません。')
+
+    def get_deadband(self, sid, callback=None):
+        raise NotSupportException('Futabaではget_deadbandに対応していません。')
+
+    def get_deadband_async(self, sid, loop=None):
+        raise NotSupportException('Futabaではget_deadband_asyncに対応していません。')
+
+    def set_deadband(self, deadband, sid):
+        raise NotSupportException('Futabaではset_deadbandに対応していません。')
+
+    def get_voltage(self, sid, callback=None):
+        """電圧取得 (単位: V)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                voltage = int.from_bytes(response_data, 'little', signed=True)
+                voltage /= 100
+                return voltage
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_VOLTAGE_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_voltage_async(self, sid, loop=None):
+        """電圧取得 async版 (単位: V)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_voltage(sid, callback=callback)
+        return f
+
+    def get_target_time(self, sid, callback=None):
+        """目標位置までのサーボ移動時間を取得 (単位: 秒)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                # 単位は 10ms 単位になっているので、秒に変更
+                speed = int.from_bytes(response_data, 'little', signed=False)
+                speed /= 100
+                return speed
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_GOAL_TIME_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_target_time_async(self, sid, loop=None):
+        """目標位置までのサーボ移動時間を取得 async版 (単位: 秒)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_target_time(sid, callback=callback)
+        return f
+
+    def set_target_time(self, speed_second, sid=1):
+        """目標位置までのサーボ移動時間を設定 (単位: 秒)
+
+        :param speed_second:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # 設定範囲は 0 から 3FFFH。つまり0秒から163830ms=163.83seconds
+        if speed_second < 0:
+            speed_second = 0
+        elif speed_second > 163.83:
+            speed_second = 163.83
+
+        # 10ms 単位で設定。この関数のパラメータは秒指定なので*100する
+        speed_hex = format(int(speed_second * 100) & 0xffff, '04x')
+        speed_hex_h = int(speed_hex[0:2], 16)
+        speed_hex_l = int(speed_hex[2:4], 16)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_GOAL_TIME_L, [speed_hex_l, speed_hex_h])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_accel_time(self, sid, callback=None):
+        raise NotSupportException('Futabaではget_accel_timeに対応していません。')
+
+    def get_accel_time_async(self, sid, loop=None):
+        raise NotSupportException('Futabaではget_accel_time_asyncに対応していません。')
+
+    def set_accel_time(self, speed_second, sid):
+        raise NotSupportException('Futabaではset_accel_timeに対応していません。')
+
+    def get_pid_coefficient(self, sid, callback=None):
+        """モータの制御係数を取得 (単位: %)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 1:
+                coef = response_data[0]
+                return coef
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_PID_COEFFICIENT, self.FLAG30_MEM_MAP_SELECT, 1, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_pid_coefficient_async(self, sid, loop=None):
+        """モータの制御係数を取得 async版 (単位: %)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_pid_coefficient(sid, callback=callback)
+        return f
+
+    def set_pid_coefficient(self, coef_percent, sid):
+        """モータの制御係数を設定 (単位: %)
+
+        :param coef_percent:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # 100%のとき設定値は、64H となります。設定範囲は 01H~FFH までです。
+        if coef_percent < 1:
+            coef_percent = 1
+        elif coef_percent == 10:
+            # なぜか10に設定すると反応がおかしいので9にシフトさせる
+            coef_percent = 9
+        elif coef_percent > 255:
+            coef_percent = 255
+
+        coef_hex = int(coef_percent)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_PID_COEFFICIENT, [coef_hex])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_p_gain(self, sid, callback=None):
+        """ pGainの取得（単位無し
+
+        :param sid:
+        :param callback
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_p_gainに対応していません。')
+
+    def get_p_gain_async(self, sid, loop=None):
+        """ pGainの取得（単位無し async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_p_gain_asyncに対応していません。')
+
+    def set_p_gain(self, gain, sid=1):
+        """ pGainの書き込み
+
+        :param gain:
+        :param sid:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_p_gainに対応していません。')
+
+
+    def get_i_gain(self, sid, callback=None):
+        """ iGainの取得（単位無し
+
+        :param sid:
+        :param callback
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_i_gainに対応していません。')
+
+
+    def get_i_gain_async(self, sid, loop=None):
+        """ iGainの取得（単位無し async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_i_gain_asyncに対応していません。')
+
+    def set_i_gain(self, gain, sid=1):
+        """ iGainの書き込み
+
+        :param gain:
+        :param sid:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_i_gainに対応していません。')
+
+
+    def get_d_gain(self, sid, callback=None):
+        """ dGainの取得（単位無し
+
+        :param sid:
+        :param callback
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_d_gainに対応していません。')
+
+
+    def get_d_gain_async(self, sid, loop=None):
+        """ dGainの取得（単位無し async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_d_gain_asyncに対応していません。')
+
+    def set_d_gain(self, gain, sid=1):
+        """ dGainの書き込み
+
+        :param gain:
+        :param sid:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_d_gainに対応していません。')
+
+    def get_max_torque(self, sid, callback=None):
+        """最大トルク取得 (%)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 1:
+                max_torque = response_data[0]
+                return max_torque
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_MAX_TORQUE, self.FLAG30_MEM_MAP_SELECT, 1, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_max_torque_async(self, sid, loop=None):
+        """最大トルク取得 async版 (%)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_max_torque(sid, callback=callback)
+        return f
+
+    def set_max_torque(self, torque_percent, sid):
+        """最大トルク設定 (%)
+
+        :param torque_percent:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # 0-100%で設定
+        if torque_percent < 0:
+            torque_percent = 0
+        elif torque_percent > 100:
+            torque_percent = 100
+
+        torque_hex = int(torque_percent)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_MAX_TORQUE, [torque_hex])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_speed(self, sid, callback=None):
+        """現在の回転速度を取得 (deg/s)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                speed = int.from_bytes(response_data, 'little', signed=True)
+                return speed
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_PRESENT_SPEED_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_speed_async(self, sid, loop=None):
+        """現在の回転速度を取得 async版 (deg/s)
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_speed(sid, callback=callback)
+        return f
+
+    def set_speed(self, dps, sid):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_speedに対応していません。set_target_time()で回転スピードを制御してください。')
+
+    def get_servo_id(self, sid, callback=None):
+        """サーボIDを取得
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 1:
+                servo_id = int.from_bytes(response_data, 'little', signed=False)
+                return servo_id
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_SERVO_ID, self.FLAG30_MEM_MAP_SELECT, 1, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_servo_id_async(self, sid, loop=None):
+        """サーボIDを取得 async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_servo_id(sid, callback=callback)
+        return f
+
+    def set_servo_id(self, new_sid, sid):
+        """サーボIDを設定
+
+        :param new_sid:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(new_sid)
+        self.__check_sid(sid)
+
+        # 0-100%で設定
+        if new_sid < 1:
+            new_sid = 1
+        elif new_sid > 127:
+            new_sid = 127
+
+        new_sid_hex = int(new_sid)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_SERVO_ID, [new_sid_hex])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def save_rom(self, sid):
+        """フラッシュROMに書き込む
+
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_WRITE_FLASH_ROM, flag=0x40, count=0)
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def load_rom(self, sid):
+        raise NotSupportException('Futabaではload_romに対応していません。')
+
+    def get_baud_rate(self, sid, callback=None):
+        """通信速度を取得
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 1:
+                baud_rate_list = [9600, 14400, 19200, 28800, 38400, 57600, 76800, 115200, 153600, 230400]
+                baud_rate_id = int.from_bytes(response_data, 'little', signed=False)
+                return baud_rate_list[baud_rate_id]
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_BAUD_RATE, self.FLAG30_MEM_MAP_SELECT, 1, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_baud_rate_async(self, sid, loop=None):
+        """通信速度を取得 async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_baud_rate(sid, callback=callback)
+        return f
+
+    def set_baud_rate(self, baud_rate, sid):
+        """通信速度を設定
+
+        :param baud_rate:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # 通信速度IDのチェック
+        baud_rate_list = [9600, 14400, 19200, 28800, 38400, 57600, 76800, 115200, 153600, 230400]
+        try:
+            baud_rate_id = baud_rate_list.index(baud_rate)
+        except:
+            raise BadInputParametersException('baud_rate が不正な値です')
+
+        baud_rate_id_hex = int(baud_rate_id)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_BAUD_RATE, [baud_rate_id_hex])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_limit_cw_position(self, sid, callback=None):
+        """右(時計回り)リミット角度の取得
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                limit_position = int.from_bytes(response_data, 'little', signed=True)
+                limit_position /= 10
+                return -limit_position
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_CW_ANGLE_LIMIT_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_limit_cw_position_async(self, sid, loop=None):
+        """右(時計回り)リミット角度の取得 async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_limit_cw_position(sid, callback=callback)
+        return f
+
+    def set_limit_cw_position(self, limit_position, sid):
+        """右(時計回り)リミット角度を設定
+
+        :param limit_position:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # リミット角度のチェック
+        if -150 < limit_position > 0:
+            raise BadInputParametersException('limit_position が不正な値です。-150〜0を設定してください。')
+
+        limit_position = -limit_position;
+
+        limit_position_hex = format(int(limit_position * 10) & 0xffff, '04x')
+        limit_position_hex_h = int(limit_position_hex[0:2], 16)
+        limit_position_hex_l = int(limit_position_hex[2:4], 16)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_CW_ANGLE_LIMIT_L, [limit_position_hex_l, limit_position_hex_h])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_limit_ccw_position(self, sid, callback=None):
+        """左(反時計回り)リミット角度の取得
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                limit_position = int.from_bytes(response_data, 'little', signed=True)
+                limit_position /= 10
+                return -limit_position
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_CCW_ANGLE_LIMIT_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_limit_ccw_position_async(self, sid, loop=None):
+        """左(反時計回り)リミット角度の取得 async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_limit_ccw_position(sid, callback=callback)
+        return f
+
+    def set_limit_ccw_position(self, limit_position, sid):
+        """左(反時計回り)リミット角度を設定
+
+        :param limit_position:
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # リミット角度のチェック
+        if 0 < limit_position > 150:
+            raise BadInputParametersException('limit_position が不正な値です。0〜150を設定してください。')
+
+        limit_position = -limit_position;
+
+        limit_position_hex = format(int((limit_position * 10) & 0xffff), '04x')
+        limit_position_hex_h = int(limit_position_hex[0:2], 16)
+        limit_position_hex_l = int(limit_position_hex[2:4], 16)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_CCW_ANGLE_LIMIT_L,
+                                          [limit_position_hex_l, limit_position_hex_h])
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_limit_temperature(self, sid, callback=None):
+        """温度リミットの取得 (℃)
+
+        :param sid:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == 2:
+                limit_temp = int.from_bytes(response_data, 'little', signed=True)
+                return limit_temp
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(self.ADDR_TEMPERATURE_LIMIT_L, self.FLAG30_MEM_MAP_SELECT, 2, response_process,
+                                   sid=sid, callback=callback)
+
+    def get_limit_temperature_async(self, sid, loop=None):
+        """温度リミットの取得 (℃) async版
+
+        :param sid:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.get_limit_temperature(sid, callback=callback)
+        return f
+
+    def set_limit_temperature(self, limit_temp, sid):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_limit_temperatureに対応していません。')
+
+    def get_limit_current(self, sid, callback=None):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_limit_currentに対応していません。')
+
+    def get_limit_current_async(self, sid, loop=None):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_limit_current_asyncに対応していません。')
+
+    def set_limit_current(self, limit_current, sid):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_limit_currentに対応していません。')
+
+    def get_drive_mode(self, sid, callback=None):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_drive_modeに対応していません。')
+    def get_drive_mode_async(self, sid, loop=None):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_drive_mode_asyncに対応していません。')
+    def set_drive_mode(self, drive_mode, sid):
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではset_drive_modeに対応していません。')
+
+
+    def set_burst_target_positions(self, sid_target_positions):
+        """複数のサーボの対象ポジションを一度に設定
+
+        :param sid_target_positions:
+        :return:
+        """
+
+        # データチェック & コマンドデータ生成
+        vid_data = {}
+        for sid, position_degree in sid_target_positions.items():
+            # サーボIDのチェック
+            self.__check_sid(sid)
+
+            # 設定可能な範囲は-150.0 度~150.0 度
+            if position_degree < -150:
+                position_degree = -150
+            elif position_degree > 150:
+                position_degree = 150
+
+            position_hex = format(int(position_degree * -10) & 0xffff, '04x')
+            position_hex_h = int(position_hex[0:2], 16)
+            position_hex_l = int(position_hex[2:4], 16)
+
+            vid_data[sid] = [position_hex_l, position_hex_h]
+
+        # コマンド生成
+        command = self.__generate_burst_command(self.ADDR_GOAL_POSITION_L, 3, vid_data)
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def get_burst_positions(self, sids, callback=None):
+        """複数のサーボの現在のポジションを一気にリード
+
+        :param sids:
+        :param callback:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_burst_positionsに対応していません。')
+
+    def get_burst_positions_async(self, sids, loop=None):
+        """複数のサーボの現在のポジションを一気にリード async版
+
+        :param sids:
+        :param loop:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではget_burst_positions_asyncに対応していません。')
+
+    def reset_memory(self, sid):
+        """ROMを工場出荷時のものに初期化する
+
+        :param sid:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # コマンド生成
+        command = self.__generate_command(sid, self.ADDR_RESET_MEMORY, flag=self.FLAG4_RESET_MEMORY_MAP, count=0)
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def read(self, sid, address, length, callback=None):
+        """データを読み込む
+
+        :param sid:
+        :param address:
+        :param length:
+        :param callback:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        def response_process(response_data):
+            if response_data is not None and len(response_data) == length:
+                return response_data
+            else:
+                raise InvalidResponseDataException('サーボからのレスポンスデータが不正です')
+
+        return self.__get_function(address, self.FLAG30_MEM_MAP_SELECT, length, response_process,
+                                   sid=sid, callback=callback)
+
+    def read_async(self, sid, address, length, loop=None):
+        """データを読み込む async版
+
+        :param sid:
+        :param address:
+        :param length:
+        :param loop:
+        :return:
+        """
+
+        f, callback = self.async_wrapper(loop)
+        self.read(sid, address, length, callback=callback)
+        return f
+
+    def write(self, sid, address, data):
+        """データを書き込む
+
+        :param sid:
+        :param address:
+        :param data:
+        :return:
+        """
+
+        # サーボIDのチェック
+        self.__check_sid(sid)
+
+        # コマンド生成
+        command = self.__generate_command(sid, address, data)
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)
+
+    def burst_read(self, address, length, sids, callback=None):
+        """複数サーボから一括でデータ読み取り
+
+        :param address:
+        :param length:
+        :param sids:
+        :param callback:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではburst_readに対応していません。')
+
+    def burst_read_async(self, address, length, sids, loop=None):
+        """複数サーボから一括でデータ読み取り async版
+
+        :param address:
+        :param length:
+        :param sids:
+        :param loop:
+        :return:
+        """
+        """Futabaでは未サポート"""
+        raise NotSupportException('Futabaではburst_read_asyncに対応していません。')
+
+    def burst_write(self, address, length, sid_data):
+        """複数サーボに一括で書き込み
+
+        :param address:
+        :param length:
+        :param sid_data:
+        :return:
+        """
+
+        # データチェック & コマンドデータ生成
+        vid_data = {}
+        for sid, data in sid_data.items():
+            # サーボIDのチェック
+            self.__check_sid(sid)
+
+            vid_data[sid] = data
+
+        # コマンド生成
+        command = self.__generate_burst_command(address, length, vid_data)
+
+        # データ送信バッファに追加
+        self.command_handler.add_command(command)

--- a/gs2d/Kondo.py
+++ b/gs2d/Kondo.py
@@ -1,5 +1,6 @@
 import time
 import logging
+import serial
 from types import FunctionType
 from packaging.version import Version
 
@@ -72,9 +73,13 @@ class KondoICS(Driver):
         """初期化
         """
 
+        super(KondoICS, self).__init__(serial_interface, command_handler_class)
         self.loopback:bool = bool(loopback)
         self.slave:bool = bool(slave)
         self.baudrate = 115200
+        if isinstance(self.command_handler.serial_interface.ser, serial.Serial):
+            self.baudrate = self.command_handler.serial_interface.ser.baudrate
+            self.command_handler.serial_interface.ser.parity = serial.PARITY_EVEN
 
         if version == "3.6":
             self.version = Version("3.6")

--- a/gs2d/SerialInterface.py
+++ b/gs2d/SerialInterface.py
@@ -53,7 +53,7 @@ class SerialInterface(ISerialInterface):
         logger.debug('Device name: {}, Baudrate: {}'.format(device, baudrate))
 
         # シリアルデバイス生成
-        self.__ser = serial.Serial(device, baudrate, timeout=0.1)
+        self.ser = serial.Serial(device, baudrate, timeout=0.1)
 
     def write(self, data):
         """データ送信
@@ -62,7 +62,7 @@ class SerialInterface(ISerialInterface):
         :return:
         """
 
-        return self.__ser.write(data)
+        return self.ser.write(data)
 
     def read(self):
         """サーボからのデータ1文字受信
@@ -70,7 +70,7 @@ class SerialInterface(ISerialInterface):
         :return:
         """
 
-        return self.__ser.read()
+        return self.ser.read()
 
     def is_open(self):
         """シリアルインタフェースがオープンされているかチェック
@@ -78,7 +78,7 @@ class SerialInterface(ISerialInterface):
         :return:
         """
 
-        return self.__ser.is_open
+        return self.ser.is_open
 
     def close(self):
         """シリアルインタフェースをクローズ
@@ -86,4 +86,4 @@ class SerialInterface(ISerialInterface):
         :return:
         """
 
-        self.__ser.close()
+        self.ser.close()

--- a/gs2d/__init__.py
+++ b/gs2d/__init__.py
@@ -1,4 +1,5 @@
-# from .Futaba import Futaba
+from .Futaba import Futaba
+from .Kondo import KondoICS
 from .RobotisP20 import RobotisP20
 from .SerialInterface import SerialInterface
 from .DefaultCommandHandler import DefaultCommandHandler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyserial
-
+packaging

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name='gs2d',
     version='0.0.4',
     description='gs2d: The Library for Generic Serial-bus Servo Driver kr-sac001 for Python',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     author='Karakuri Products',
     author_email='gs2d@krkrpro.com',


### PR DESCRIPTION
KONDOのICSパケットサポートを追加しました。
KONDOのパケットは送信と受信がセットのため、sendのみではなくreceiveまで待って値等を取得するようにしています。

コンストラクタの引数ですが、以下を拡張で追加しています。

* version: ICSのバージョンを明示的に指定するように追加
* loopback: DualUSBアダプタは送信コマンドを受信するため、受信バイト数調整のために追加
* slave: KONDOサーボのスレーブモードは値を返却しないため追加

またTODOコメントを入れて処理を実装していない関数がいくつかあるのですが、これらはプロトコル上対応可能だけど私の時間が取れなかったため実装できていないものです。
動作チェックは角度の取得、指示に関してはできていますが他は確認していません。
塩漬けになりそうだったので、一旦プルリクエストさせてください。